### PR TITLE
monotime: add Since function

### DIFF
--- a/monotime/example_test.go
+++ b/monotime/example_test.go
@@ -1,0 +1,14 @@
+package monotime_test
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/aristanetworks/goarista/monotime"
+)
+
+func Example() {
+	start := monotime.Now()
+	time.Sleep(1 * time.Nanosecond)
+	fmt.Println(monotime.Since(start))
+}

--- a/monotime/nanotime.go
+++ b/monotime/nanotime.go
@@ -6,6 +6,7 @@
 package monotime
 
 import (
+	"time"
 	_ "unsafe" // required to use //go:linkname
 )
 
@@ -21,4 +22,10 @@ func nanotime() int64
 // seconds.
 func Now() uint64 {
 	return uint64(nanotime())
+}
+
+// Since returns the amount of time that has elapsed since t. t should be
+// the result of a call to Now() on the same machine.
+func Since(t uint64) time.Duration {
+	return time.Duration(Now() - t)
 }

--- a/monotime/nanotime_test.go
+++ b/monotime/nanotime_test.go
@@ -7,6 +7,7 @@ package monotime_test
 
 import (
 	"testing"
+	"time"
 
 	. "github.com/aristanetworks/goarista/monotime"
 )
@@ -19,6 +20,21 @@ func TestNow(t *testing.T) {
 		// two consecutive calls can return the same value!
 		if t1 > t2 {
 			t.Fatalf("t1=%d should have been less than or equal to t2=%d", t1, t2)
+		}
+	}
+}
+
+func TestSince(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		t1 := Now()
+		time.Sleep(1)
+		dur := Since(t1)
+		if dur <= 0 {
+			t.Fatalf("dur=%v should have been greater than 0", dur)
+		}
+		// avg value here is 5 nanoseconds but let's be safe.
+		if dur >= 10*time.Millisecond {
+			t.Fatalf("dur=%v was too large", dur)
 		}
 	}
 }


### PR DESCRIPTION
This is a convenience function for computing the elapsed time since a given
timestamp, as it's a little cumbersome to type

`time.Duration(monotime.Now() - start)`

over and over. Adds an example to show how it should be used.

This adds a dependency on the time package, which might not be desirable.