### PR TITLE
fix go1.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ go:
 # Master disabled while until key.composite is replaced
 # - master
 env:
-# GOSUMDB is to make go1.12 behave like go1.13
-- GO111MODULE=on GOSUMDB=sum.golang.org
+# GOPROXY is set for the benefit of go1.12, make it behave like go1.13 (without the direct, since it doesn't like ,)
+- GO111MODULE="on" GOPROXY="https://proxy.golang.org"
 before_install:
 - go get -v golang.org/x/lint/golint
 - go get -v -t -d ./...


### PR DESCRIPTION
pinky promise this is it.

Here's the problem;
go1.13 has GOSUMDB and GOPROXY set up. Using go1.13, tjfoc/gmsm@v1.3.0
was downloaded from the proxy. go1.13 verified the thing it downloaded
matched the checksum from GOSUMDB, wrote the checksum in sum.go, and
went about its way.

Now, telling go1.12 to download the modules fails on the checksum of
the above package. The issue being that for some reason, downloading
gmsm from github, its checksum is different from what GOSUMDB has. And
why does go1.12 not use proxy.golang.org? Because GOPROXY is not set
in that version of go. Setting GOPROXY makes go1.12 download the right
version of gmsm and this all goes away.
