### PR TITLE
Add a sample ocprometheus.spec file

### DIFF
--- a/cmd/ocprometheus/README.md
+++ b/cmd/ocprometheus/README.md
@@ -35,3 +35,29 @@ in the sample config file:
 ```
 ocprometheus -addr <switch-hostname>:6042 -config sampleconfig.json
 ```
+
+## Deployment
+
+This can be packaged as a swix package to ease the deployment on the devices.
+For this a sample ocprometheus.spec file is proposed.
+
+Here are some instructions, that were tested on OpenSUSE, which you should
+adapt for your environment and the version you wish to use.
+
+Build the rpm:
+
+```
+rpmbuild --undefine=_disable_source_fetch -ba ocprometheus.spec
+rpmbuild --target i686 -ba ocprometheus.spec
+```
+
+Package it as a swix package using a cEOS-lab Docker image:
+
+```
+docker run --rm -ti -v $HOME/rpmbuild:/vol --entrypoint=swix ceosimage:4.24.3 \
+  create /vol/ocprometheus-0.0.2-1.i686.swix /vol/RPMS/i686/ocprometheus-0.0.2-1.i686.rpm --force
+```
+
+You can now install the swix as a normal extension.
+
+

--- a/cmd/ocprometheus/ocprometheus.spec
+++ b/cmd/ocprometheus/ocprometheus.spec
@@ -1,0 +1,28 @@
+Name:           ocprometheus
+Version:        0.0.2
+Release:        1%{?dist}
+Summary:        ocprometheus
+License:        Apache2.0
+Source0:        https://github.com/aristanetworks/goarista/archive/ocprometheus-v%{version}.tar.gz 
+BuildRequires:  go1.14
+
+BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
+
+%description
+
+%prep
+%setup -q -n goarista-ocprometheus-v%{version}
+
+%build
+    cd cmd/ocprometheus && ( GOOS=linux GOARCH=386 go build )
+
+%install
+    mkdir -p %{buildroot}/usr/bin
+    cp cmd/ocprometheus/ocprometheus %{buildroot}/usr/bin/
+
+%files
+    /usr/bin/ocprometheus
+
+%post
+%postun
+


### PR DESCRIPTION
In case you are interested.

https://eos.arista.com/streaming-eos-telemetry-states-to-prometheus/
suggested the usage of fpm but I found it easier to just use rpmbuild.

In anycase, is it possible to deliver a 0.0.2 version (or even.. a 1.0.0 ?) the last release in github was made a while ago. I prefer to use the released tarball with a tagged version.

Cheers!