### PR TITLE
gnmi: Fix StrVal for Decimal64

### DIFF
--- a/gnmi/operation.go
+++ b/gnmi/operation.go
@@ -220,10 +220,19 @@ func strDecimal64(d *pb.Decimal64) string {
 	} else {
 		i = d.Digits
 	}
+	format := "%d.%0*d"
 	if frac < 0 {
+		if i == 0 {
+			// The integer part doesn't provide the necessary minus sign.
+			format = "-" + format
+		}
 		frac = -frac
 	}
-	return fmt.Sprintf("%d.%d", i, frac)
+	p := int(d.Precision)
+	if p == 0 {
+		p = 1 // No trailing decimal point
+	}
+	return fmt.Sprintf(format, i, int(d.Precision), frac)
 }
 
 // strLeafList builds a human-readable form of a leaf-list. e.g. [1, 2, 3] or [a, b, c]

--- a/gnmi/operation_test.go
+++ b/gnmi/operation_test.go
@@ -257,9 +257,37 @@ func TestStrUpdateVal(t *testing.T) {
 		"DecimalVal": {
 			update: &pb.Update{Val: &pb.TypedValue{
 				Value: &pb.TypedValue_DecimalVal{
-					DecimalVal: &pb.Decimal64{Digits: 314, Precision: 2},
+					DecimalVal: &pb.Decimal64{Digits: 3014, Precision: 3},
 				}}},
-			exp: "3.14",
+			exp: "3.014",
+		},
+		"DecimalValWithLeadingZeros": {
+			update: &pb.Update{Val: &pb.TypedValue{
+				Value: &pb.TypedValue_DecimalVal{
+					DecimalVal: &pb.Decimal64{Digits: 314, Precision: 6},
+				}}},
+			exp: "0.000314",
+		},
+		"DecimalValWithLeadingZerosInFraction": {
+			update: &pb.Update{Val: &pb.TypedValue{
+				Value: &pb.TypedValue_DecimalVal{
+					DecimalVal: &pb.Decimal64{Digits: 3000141, Precision: 6},
+				}}},
+			exp: "3.000141",
+		},
+		"DecimalValWithZeroPrecision": {
+			update: &pb.Update{Val: &pb.TypedValue{
+				Value: &pb.TypedValue_DecimalVal{
+					DecimalVal: &pb.Decimal64{Digits: 314, Precision: 0},
+				}}},
+			exp: "314.0",
+		},
+		"DecimalValWithNegativeFraction": {
+			update: &pb.Update{Val: &pb.TypedValue{
+				Value: &pb.TypedValue_DecimalVal{
+					DecimalVal: &pb.Decimal64{Digits: -314, Precision: 3},
+				}}},
+			exp: "-0.314",
 		},
 		"LeafListVal": {
 			update: &pb.Update{Val: &pb.TypedValue{


### PR DESCRIPTION
Corrected display of values such as:
- 3.014
- 0.000314
- -0.314

aristanetworks#71
aristanetworks#72