### PR TITLE
Update go version in dockerfiles

### DIFF
--- a/cmd/ockafka/Dockerfile
+++ b/cmd/ockafka/Dockerfile
@@ -2,7 +2,7 @@
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the COPYING file.
 
-FROM golang:1.13.6
+FROM golang:1.24.0
 
 RUN mkdir -p /go/src/github.com/aristanetworks/goarista/cmd
 WORKDIR /go/src/github.com/aristanetworks/goarista

--- a/cmd/ocprometheus/Dockerfile
+++ b/cmd/ocprometheus/Dockerfile
@@ -2,7 +2,7 @@
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the COPYING file.
 
-FROM golang:1.13.6
+FROM golang:1.24.0
 
 RUN mkdir -p /go/src/github.com/aristanetworks/goarista/cmd
 WORKDIR /go/src/github.com/aristanetworks/goarista


### PR DESCRIPTION
The existing dockerfiles were unbuildable because they would fail with:

build github.com/aristanetworks/goarista/cmd/ocprometheus: cannot load embed: malformed module path "embed": missing dot in first path element